### PR TITLE
[vtt] fix linefeeds coming in from different sources

### DIFF
--- a/lib/caption_crunch/adapters/vtt.rb
+++ b/lib/caption_crunch/adapters/vtt.rb
@@ -11,14 +11,15 @@ module CaptionCrunch
       #         102:01:43:204
       # http://dev.w3.org/html5/webvtt/#dfn-collect-a-webvtt-timestamp
       TIME_REGEX      = /\A(?:(\d\d+):)?([0-5]\d):([0-5]\d)\.(\d\d\d)\Z/.freeze
-      NEWLINE_REGEX   = /\r\n|\r|\n/.freeze
+      NEWLINE_REGEX   = /\n/.freeze
 
       class << self
         # Reads a file (or string) and returns a CaptionCrunch::Track instance.
         # Raises CaptionCrunch::ParseError if the input is malformed.
         def parse(file)
           contents = remove_bom(read_file(file))
-          segments = split_segments(contents)
+          normalized = normalize_linefeeds(contents)
+          segments = split_segments(normalized)
           ensure_signature(segments.shift)
 
           Track.new.tap do |track|
@@ -47,6 +48,10 @@ module CaptionCrunch
           else
             string
           end
+        end
+
+        def normalize_linefeeds(string)
+          string.encode(string.encoding, universal_newline: true)
         end
 
         # The WebVTT spec separates segments by two newlines or more.

--- a/spec/caption_crunch_spec.rb
+++ b/spec/caption_crunch_spec.rb
@@ -127,5 +127,17 @@ describe 'CaptionCrunch' do
       end
     end
 
+    describe 'parsing cue with Windows-style line-endings' do
+      subject do
+        contents = "WEBVTT\r\n\r\n00:00:00.000 --> 00:00:02.000\r\nI work!"
+        CaptionCrunch.parse(contents)
+      end
+
+      it 'should parse correctly' do
+        subject.cues.count.must_equal 1
+        subject.cues.first.payload.must_equal "I work!"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Windows linefeeds are `\r\n`, but my regex was too greedy. You have to `gsub` `\r\n` out first, then `gsub` the rest.

Trello: https://trello.com/c/29i4Yext/266-captions-engine-not-recognizing-vtt-files
